### PR TITLE
Necesitas cambiar el tipo de dato de tu columna monto para que pueda …

### DIFF
--- a/prisma/migrations/20250504042816_change_referenciales_monto_to_bigint/migration.sql
+++ b/prisma/migrations/20250504042816_change_referenciales_monto_to_bigint/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "referenciales" ALTER COLUMN "monto" DROP NOT NULL,
+ALTER COLUMN "monto" SET DATA TYPE BIGINT,
+ALTER COLUMN "updatedAt" DROP DEFAULT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,7 +61,7 @@ model referenciales {
   rol            String
   fechaescritura DateTime
   superficie     Float
-  monto          Int
+  monto          BigInt?       // <-- CAMBIO REALIZADO: Int a BigInt.
   observaciones  String?
   userId         String
   conservadorId  String        


### PR DESCRIPTION
…almacenar números más grandes. El tipo adecuado es BIGINT (entero de 64 bits), que puede almacenar números muchísimo más grandes.