### PR TITLE
🐛 Corregir error de tipos en la exportación a Excel

### DIFF
--- a/lib/exportToXlsx.ts
+++ b/lib/exportToXlsx.ts
@@ -1,8 +1,35 @@
 // lib/exportToXlsx.ts
 import ExcelJS from 'exceljs';
-import { referenciales } from '@prisma/client';
 
-export const exportReferencialesToXlsx = async (referenciales: referenciales[], headers: { key: keyof referenciales, label: string }[]) => {
+// Definimos una interfaz para los datos exportables
+interface ExportableReferencial {
+  id: string;
+  lat: number;
+  lng: number;
+  fojas: string;
+  numero: number;
+  anio: number;
+  cbr: string;
+  comprador: string;
+  vendedor: string;
+  predio: string;
+  comuna: string;
+  rol: string;
+  fechaescritura: Date;
+  superficie: number;
+  monto: number | bigint | null;
+  observaciones: string | null;
+  userId: string;
+  conservadorId: string;
+  createdAt: Date;
+  updatedAt: Date;
+  [key: string]: any; // Para permitir propiedades adicionales como conservadorNombre
+}
+
+export const exportReferencialesToXlsx = async (
+  referenciales: ExportableReferencial[], 
+  headers: { key: string, label: string }[]
+) => {
   const workbook = new ExcelJS.Workbook();
   const worksheet = workbook.addWorksheet('Referenciales');
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -12,8 +12,16 @@ export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(...inputs));
 }
 
-export const formatCurrency = (amount: number) => {
-  return (amount / 100).toLocaleString('en-US', {
+export const formatCurrency = (amount: number | bigint | null) => {
+  // Si es null o undefined, devolver un valor por defecto
+  if (amount === null || amount === undefined) {
+    return '$0.00';
+  }
+  
+  // Convertir a number si es bigint
+  const numericAmount = typeof amount === 'bigint' ? Number(amount) : amount;
+  
+  return (numericAmount / 100).toLocaleString('en-US', {
     style: 'currency',
     currency: 'USD',
   });


### PR DESCRIPTION
## Descripción

Esta PR soluciona el error de tipo en la función de exportación a Excel que continúa impidiendo el despliegue en Vercel. El error específico es:

```
Type 'number' is not assignable to type 'bigint'.
```

### Análisis del problema

El problema se debe a un conflicto de tipos entre:

1. La definición del campo `monto` en el esquema de Prisma como `BigInt?`
2. La conversión que hacemos de `bigint` a `number` en el componente de UI
3. La dependencia en `exportToXlsx.ts` del tipo autogenerado por Prisma, que espera un `bigint`

Esto resulta en un conflicto cuando pasamos exportableData (con `monto` como `number`) a una función que espera `referenciales[]` del cliente Prisma (con `monto` como `bigint`).

### Solución implementada

1. **Creación de una interfaz personalizada `ExportableReferencial`**:
   - Define explícitamente todos los campos necesarios para la exportación
   - Acepta múltiples tipos para `monto`: `number | bigint | null`
   - Permite propiedades adicionales como `conservadorNombre` con `[key: string]: any`

2. **Actualización de la función de exportación**:
   - Modificada la firma para usar `ExportableReferencial[]` en lugar del tipo autogenerado por Prisma
   - Cambio del tipo de parámetros a `key: string` para mayor flexibilidad

### Ventajas

- **Desacoplamiento de tipos**: Ya no dependemos del tipo autogenerado de Prisma
- **Mayor flexibilidad**: Podemos incluir propiedades adicionales para la exportación
- **Compatibilidad de entornos**: Funciona tanto con `number` como con `bigint` para el campo `monto`

### Consideraciones

Este cambio requiere verificación cuidadosa en Vercel para asegurar que el error se ha resuelto. No se debe fusionar hasta confirmar el despliegue exitoso.

### Pruebas recomendadas

1. Verificar que la exportación a Excel funciona localmente
2. Confirmar el despliegue exitoso en Vercel
3. Probar la exportación en el entorno de producción una vez desplegado

Esta PR es parte de una serie de mejoras para resolver los problemas de compatibilidad de tipos entre el entorno local y Vercel, específicamente relacionados con el manejo de `BigInt` en PostgreSQL.